### PR TITLE
Add some jobs related endpoint support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -49,7 +49,7 @@ export const ProjectsBundle = Bundler(Pick(APIServices, [
   'MergeRequestAwardEmojis',
   'MergeRequestNotes',
   'Pipelines',
-  'PipelineSchedules',
+  'PipelineJobs',
   'PipelineScheduleVariables',
   'Projects',
   'ProjectAccessRequests',

--- a/src/index.js
+++ b/src/index.js
@@ -50,6 +50,7 @@ export const ProjectsBundle = Bundler(Pick(APIServices, [
   'MergeRequestNotes',
   'Pipelines',
   'PipelineJobs',
+  'PipelineSchedules',
   'PipelineScheduleVariables',
   'Projects',
   'ProjectAccessRequests',

--- a/src/services/Jobs.js
+++ b/src/services/Jobs.js
@@ -6,6 +6,12 @@ class Jobs extends BaseService {
 
     return RequestHelper.get(this, `projects/${pId}/jobs`, options);
   }
+
+  downloadSingleArtifactFile(projectId, jobId, artifactPath) {
+    const pId = encodeURIComponent(projectId);
+
+    return RequestHelper.get(this, `projects/${pId}/jobs/${jobId}/artifacts/${artifactPath}`);
+  }
 }
 
 export default Jobs;

--- a/src/services/PipelineJobs.js
+++ b/src/services/PipelineJobs.js
@@ -1,0 +1,11 @@
+import { BaseService, RequestHelper } from '../infrastructure';
+
+class PipelineJobs extends BaseService {
+  all(projectId, pipelineId) {
+    const pId = encodeURIComponent(projectId);
+
+    return RequestHelper.get(this, `projects/${pId}/pipelines/${pipelineId}/jobs`);
+  }
+}
+
+export default PipelineJobs;

--- a/src/services/PipelineJobs.js
+++ b/src/services/PipelineJobs.js
@@ -1,10 +1,10 @@
 import { BaseService, RequestHelper } from '../infrastructure';
 
 class PipelineJobs extends BaseService {
-  all(projectId, pipelineId) {
+  all(projectId, pipelineId, options = {}) {
     const pId = encodeURIComponent(projectId);
 
-    return RequestHelper.get(this, `projects/${pId}/pipelines/${pipelineId}/jobs`);
+    return RequestHelper.get(this, `projects/${pId}/pipelines/${pipelineId}/jobs`, options);
   }
 }
 

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -37,6 +37,7 @@ export MergeRequests from './MergeRequests';
 export MergeRequestAwardEmojis from './MergeRequestAwardEmojis';
 export MergeRequestNotes from './MergeRequestNotes';
 export Pipelines from './Pipelines';
+export PipelineJobs from './PipelineJobs';
 export PipelineSchedules from './PipelineSchedules';
 export PipelineScheduleVariables from './PipelineScheduleVariables';
 export Projects from './Projects';


### PR DESCRIPTION
Add support for :

1. Listing the job from a specific pipeline via `PipelineJobs.all`
1. Download the content from a specific file from the artifacts of a specific job via `Jobs.downloadSingleArtifactFile` 